### PR TITLE
fix: Firefox XRay vision prevents window<->content script messaging

### DIFF
--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -12,14 +12,12 @@ const endpointRuntime = createEndpointRuntime('content-script', (message) => {
 })
 
 win.onMessage((message: InternalMessage) => {
-  // a message event inside `content-script` means a script inside `window` dispatched it to be forwarded
-  // so we're making sure that the origin is not tampered (i.e script is not masquerading it's true identity)
-  message.origin = {
-    context: 'window',
-    tabId: null,
-  }
-
-  endpointRuntime.handleMessage(message)
+  endpointRuntime.handleMessage(Object.assign({}, message, {origin: {
+    // a message event inside `content-script` means a script inside `window` dispatched it to be forwarded
+    // so we're making sure that the origin is not tampered (i.e script is not masquerading it's true identity)
+    context: "window",
+    tabId: null
+  }}))
 })
 
 port.onMessage(endpointRuntime.handleMessage)


### PR DESCRIPTION
As current code modifies original `message` it causes the following error in latest version of Firefox:
```
Not allowed to define cross-origin object as property on [Object] or [Array] XrayWrapper
    <anonymous> content-script.js:26
    portP chunk-ICLXI4BR.js:56
    (Async: EventHandlerNonNull)
    acceptMessagingPort chunk-ICLXI4BR.js:8
    (Async: EventListener.handleEvent)
    promise chunk-ICLXI4BR.js:28
    getMessagePort chunk-ICLXI4BR.js:3
    setNamespace chunk-ICLXI4BR.js:56
    allowWindowMessaging content-script.js:46
```

More about Xray Vision here: https://firefox-source-docs.mozilla.org/dom/scriptSecurity/xray_vision.html

