### PR TITLE
chore(docs): All these imports are only used as types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Create `shim.d.ts` file with the following content and make sure it's been inclu
 ```ts
 // shim.d.ts
 
-import { ProtocolWithReturn } from "webext-bridge";
+import type { ProtocolWithReturn } from "webext-bridge";
 
 declare module "webext-bridge" {
   export interface ProtocolMap {


### PR DESCRIPTION
![image](https://github.com/serversideup/webext-bridge/assets/104723527/0c6575a3-2893-40a6-9b79-53db8256d798)
