### PR TITLE
[Doc]: The example is misleading regarding the input parameters

### DIFF
--- a/docs/content/docs/2.getting-started/2.quick-example.md
+++ b/docs/content/docs/2.getting-started/2.quick-example.md
@@ -16,9 +16,7 @@ label: Popup
 ---
 ```javascript
 import { sendMessage, onMessage } from "webext-bridge/popup";
-const response = await sendMessage("ACTION", {
-    data: data
-}, "background");
+const response = await sendMessage("ACTION", data, "background");
 ```
 ::
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4f80175e-ed49-44f8-83c6-a1a2f8f6de42)

I'm developing an OSS project, but unfortunately it doesn't have typescript. I opened the documentation and realized the example is very misleading

```typescript
import { sendMessage, onMessage } from "webext-bridge/popup";
const response = await sendMessage("ACTION", {
    data: data
}, "background");
```

This causes the misunderstanding that we need to pass the argument as an object with `data`. It is a big misunderstanding that we just need to

```typescript
import { sendMessage, onMessage } from "webext-bridge/popup";
const response = await sendMessage("ACTION", data, "background");
```

If we follow the example, `background` `({ data })` will be an object with a data field containing the data of `sendMessage` lmao


```typescript
import { sendMessage, onMessage } from "webext-bridge/popup";
const response = await sendMessage("ACTION", {
    data: data
}, "background");
```
