### PR TITLE
fix: Firefox cross-origin object access

### DIFF
--- a/src/internal/message-port.ts
+++ b/src/internal/message-port.ts
@@ -16,9 +16,10 @@ export const getMessagePort = (
       const { data: { cmd, scope, context }, ports } = event
       if (cmd === 'webext-port-offer' && scope === namespace && context !== thisContext) {
         window.removeEventListener('message', acceptMessagingPort)
-        ports[0].onmessage = onMessage
-        ports[0].postMessage('port-accepted')
-        return resolve(ports[0])
+        const port = ports[0]
+        port.onmessage = onMessage
+        port.postMessage('port-accepted')
+        return resolve(port)
       }
     }
 


### PR DESCRIPTION
## PR: Resolve Firefox cross-origin object access issue in message port handling

### Issue
Firefox was throwing the following error when attempting to handle message ports:

```
Error: Not allowed to define cross-origin object as property on [Object] or [Array] XrayWrapper
```

![image](https://github.com/user-attachments/assets/c2039680-b6ba-4a0a-b13c-b76cbd89ad0b)


### Solution
The fix involves modifying how we handle the message port in the `getMessagePort` function. Instead of directly accessing and modifying `ports[0]`, we now store it in a local variable `port`. This approach avoids the cross-origin object access issue.

### Changes
In `src/internal/message-port.ts`:

```typescript:src/internal/message-port.ts
export const getMessagePort = (
  // ... existing code ...
) => {
  // ... existing code ...
  window.addEventListener('message', function acceptMessagingPort(event) {
    const { data: { cmd, scope, context }, ports } = event
    if (cmd === 'webext-port-offer' && scope === namespace && context !== thisContext) {
      window.removeEventListener('message', acceptMessagingPort)
      const port = ports[0]
      port.onmessage = onMessage
      port.postMessage('port-accepted')
      return resolve(port)
    }
  }
  // ... existing code ...
}
```

### Impact
This change resolves the Firefox-specific error without affecting functionality on other browsers. It ensures consistent behavior across different browser environments when handling message ports in cross-origin contexts.

### Testing
- Verified that the error no longer occurs on Firefox.
- Ensured that the functionality remains intact on other supported browsers.

Please review and test this change to confirm it resolves the issue without introducing any regressions.